### PR TITLE
Support SVG as diagram output format

### DIFF
--- a/macro-plantuml-macro/pom.xml
+++ b/macro-plantuml-macro/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>net.sourceforge.plantuml</groupId>
       <artifactId>plantuml</artifactId>
-      <version>1.2023.9</version>
+      <version>1.2025.2</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.rendering</groupId>

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
@@ -37,7 +37,7 @@ public interface PlantUMLConfiguration
     String getPlantUMLServerURL();
 
     /**
-     * @return the (optional) PlantUML output format (e.g. {@code svg}, {@code png})
+     * @return the (optional) PlantUML output format (e.g. {@code svg}, {@code png}, {@code txt})
      * or null if not defined
      * @since 2.4
      */

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
@@ -37,13 +37,12 @@ public interface PlantUMLConfiguration
     String getPlantUMLServerURL();
 
     /**
-     * @return the (optional) PlantUML output format (e.g. {@code svg}, {@code png}, {@code txt})
-     * or null if not defined
+     * @return {@link PlantUMLDiagramFormat}
      * @since 2.4
      */
-    default String getPlantUMLOutputFormat()
+    default PlantUMLDiagramFormat getPlantUMLOutputFormat()
     {
         // fallback for backward compatibility
-        return null;
+        return PlantUMLDiagramFormat.png;
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
@@ -31,7 +31,15 @@ import org.xwiki.component.annotation.Role;
 public interface PlantUMLConfiguration
 {
     /**
-     * @return the (optional) PlantUML server URL (e.g. {@code http://www.plantuml.com/plantuml}) or null if not defined
+     * @return the (optional) PlantUML server URL (e.g. {@code https://www.plantuml.com/plantuml})
+     * or null if not defined
      */
     String getPlantUMLServerURL();
+
+    /**
+     * @return the (optional) PlantUML output format (e.g. {@code svg}, {@code png})
+     * or null if not defined
+     * @since 2.4
+     */
+    String getPlantUMLOutputFormat();
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLConfiguration.java
@@ -41,5 +41,9 @@ public interface PlantUMLConfiguration
      * or null if not defined
      * @since 2.4
      */
-    String getPlantUMLOutputFormat();
+    default String getPlantUMLOutputFormat()
+    {
+        // fallback for backward compatibility
+        return null;
+    }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLDiagramFormat.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLDiagramFormat.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.plantuml;
+
+import net.sourceforge.plantuml.FileFormat;
+
+/**
+ * Map macro parameter to PlantUML File Format for internal rendering and Path Parameter for external rendering.
+ *
+ * @version $Id$
+ * @since 2.4
+ */
+public enum PlantUMLDiagramFormat
+{
+    /**
+     * Map {@code svg} as a macro parameter
+     * to {@link net.sourceforge.plantuml.FileFormat#SVG} for internal rendering
+     * and {@code svg} path parameter for external rendering.
+     */
+    svg(FileFormat.SVG),
+    /**
+     * Map {@code png} as a macro parameter
+     * to {@link net.sourceforge.plantuml.FileFormat#PNG} for internal rendering
+     * and {@code png} path parameter for external rendering.
+     */
+    png(FileFormat.PNG);
+
+    private final FileFormat fileFormat;
+
+    PlantUMLDiagramFormat(FileFormat fileFormat)
+    {
+        this.fileFormat = fileFormat;
+    }
+
+    /**
+     * Get FileFormat enum element for internal (local) rendering.
+     * @return PlantUML FileFormat
+     */
+    public FileFormat getFileFormat()
+    {
+        return fileFormat;
+    }
+
+    /**
+     * Get output format path parameter URL fragment for external server rendering.
+     * The complete PlantUML URL is in the form: {@code https://plantuml.com/plantuml/format/encoded},
+     * where {@code format} is {@code svg}, {@code png}
+     * and {@code encoded} is compressed diagram definition.
+     * @return diagram format path parameter
+     */
+    public String getPathParameter()
+    {
+        return name();
+    }
+
+    /**
+     * Resolve PlantUML diagram output format by configuration parameter
+     * with fallback to {@link PlantUMLDiagramFormat#png} for unknown values.
+     *
+     * @param format parameter's value (e.g. {@code svg}, {@code png})
+     * @return corresponding {@link PlantUMLDiagramFormat} with specific {@link net.sourceforge.plantuml.FileFormat}
+     */
+    public static PlantUMLDiagramFormat fromString(String format)
+    {
+        for (PlantUMLDiagramFormat enumItem : PlantUMLDiagramFormat.values()) {
+            if (enumItem.name().equalsIgnoreCase(format)) {
+                return enumItem;
+            }
+        }
+        return png;
+    }
+}

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLDiagramFormat.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLDiagramFormat.java
@@ -40,7 +40,13 @@ public enum PlantUMLDiagramFormat
      * to {@link net.sourceforge.plantuml.FileFormat#PNG} for internal rendering
      * and {@code png} path parameter for external rendering.
      */
-    png(FileFormat.PNG);
+    png(FileFormat.PNG),
+    /**
+     * Map {@code txt} as a macro parameter
+     * to {@link net.sourceforge.plantuml.FileFormat#ATXT} for internal rendering
+     * and {@code txt} path parameter for external rendering.
+     */
+    txt(FileFormat.ATXT);
 
     private final FileFormat fileFormat;
 
@@ -61,7 +67,7 @@ public enum PlantUMLDiagramFormat
     /**
      * Get output format path parameter URL fragment for external server rendering.
      * The complete PlantUML URL is in the form: {@code https://plantuml.com/plantuml/format/encoded},
-     * where {@code format} is {@code svg}, {@code png}
+     * where {@code format} is {@code svg}, {@code png}, {@code txt}
      * and {@code encoded} is compressed diagram definition.
      * @return diagram format path parameter
      */
@@ -74,7 +80,7 @@ public enum PlantUMLDiagramFormat
      * Resolve PlantUML diagram output format by configuration parameter
      * with fallback to {@link PlantUMLDiagramFormat#png} for unknown values.
      *
-     * @param format parameter's value (e.g. {@code svg}, {@code png})
+     * @param format parameter's value (e.g. {@code svg}, {@code png}, {@code txt})
      * @return corresponding {@link PlantUMLDiagramFormat} with specific {@link net.sourceforge.plantuml.FileFormat}
      */
     public static PlantUMLDiagramFormat fromString(String format)

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
@@ -48,10 +48,7 @@ public interface PlantUMLGenerator
     @Deprecated
     default void outputImage(String input, OutputStream output, String serverURL) throws IOException
     {
-        // TODO: Scheduled for removal in an upcoming release.
-        // Implementations prior to 2.4 have this method overridden.
-        // New implementations must override {@link #outputImage(String, OutputStream, String, PlantUMLDiagramFormat)}.
-        throw new UnsupportedOperationException("Deprecated method");
+        outputImage(input, output, serverURL, PlantUMLDiagramFormat.png);
     }
 
     /**
@@ -70,8 +67,7 @@ public interface PlantUMLGenerator
     default void outputImage(String input, OutputStream output, String serverURL, PlantUMLDiagramFormat format)
             throws IOException
     {
-        // TODO: After transition period, this default method implementation must be removed.
-        // Default method implementation is for backward compatibility only.
-        outputImage(input, output, serverURL);
+        // Default method implementation is for backward compatibility.
+        throw new IOException("Not implemented");
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
@@ -42,10 +42,36 @@ public interface PlantUMLGenerator
      *        empty string or not null then the URL is called to get the generated image. Otherwise PlantUML works in
      *        embedded mode (requires installation of Graphviz locally for most diagram types, and the {@code
      *        GRAPHVIZ_DOT} environment variable must be set to point to the path of the GraphViz executable).
+     * @throws IOException when there's a generation or writing error
+     * @deprecated replaced with {@link #outputImage(String, OutputStream, String, PlantUMLDiagramFormat)}
+     */
+    @Deprecated
+    default void outputImage(String input, OutputStream output, String serverURL) throws IOException
+    {
+        // TODO: Scheduled for removal in an upcoming release.
+        // Implementations prior to 2.4 have this method overridden.
+        // New implementations must override {@link #outputImage(String, OutputStream, String, PlantUMLDiagramFormat)}.
+        throw new UnsupportedOperationException("Deprecated method");
+    }
+
+    /**
+     * Generate the image in the passed output parameter, using PlantUML.
+     *
+     * @param input the textual definition input
+     * @param output the stream into which the generated image will be written to
+     * @param serverURL the optional plantUML server URL (e.g. {@code https://www.plantuml.com/plantuml}. If not an
+     *        empty string or not null then the URL is called to get the generated image. Otherwise PlantUML works in
+     *        embedded mode (requires installation of Graphviz locally for most diagram types, and the {@code
+     *        GRAPHVIZ_DOT} environment variable must be set to point to the path of the GraphViz executable).
      * @param format the diagram output format (see {@link PlantUMLDiagramFormat})
      * @throws IOException when there's a generation or writing error
      * @since 2.4
      */
-    void outputImage(String input, OutputStream output, String serverURL, PlantUMLDiagramFormat format)
-            throws IOException;
+    default void outputImage(String input, OutputStream output, String serverURL, PlantUMLDiagramFormat format)
+            throws IOException
+    {
+        // TODO: After transition period, this default method implementation must be removed.
+        // Default method implementation is for backward compatibility only.
+        outputImage(input, output, serverURL);
+    }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLGenerator.java
@@ -38,11 +38,14 @@ public interface PlantUMLGenerator
      *
      * @param input the textual definition input
      * @param output the stream into which the generated image will be written to
-     * @param serverURL the optional plantUML server URL (e.g. {@code http://www.plantuml.com/plantuml}. If not an
+     * @param serverURL the optional plantUML server URL (e.g. {@code https://www.plantuml.com/plantuml}. If not an
      *        empty string or not null then the URL is called to get the generated image. Otherwise PlantUML works in
      *        embedded mode (requires installation of Graphviz locally for most diagram types, and the {@code
      *        GRAPHVIZ_DOT} environment variable must be set to point to the path of the GraphViz executable).
+     * @param format the diagram output format (see {@link PlantUMLDiagramFormat})
      * @throws IOException when there's a generation or writing error
+     * @since 2.4
      */
-    void outputImage(String input, OutputStream output, String serverURL) throws IOException;
+    void outputImage(String input, OutputStream output, String serverURL, PlantUMLDiagramFormat format)
+            throws IOException;
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLMacroParameters.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLMacroParameters.java
@@ -38,6 +38,8 @@ public class PlantUMLMacroParameters
 
     private PlantUMLDiagramType type;
 
+    private PlantUMLDiagramFormat format;
+
     /**
      * @param serverURL see {@link #getServer()}
      */
@@ -48,11 +50,30 @@ public class PlantUMLMacroParameters
     }
 
     /**
-     * @return the (optional) PlantUML server URL (e.g. {@code http://www.plantuml.com/plantuml})
+     * @return the (optional) PlantUML server URL (e.g. {@code https://www.plantuml.com/plantuml})
      */
     public String getServer()
     {
         return this.serverURL;
+    }
+
+    /**
+     * @param format see {@link #getFormat()}
+     * @since 2.4
+     */
+    @PropertyDescription("the PlantUML diagram output format")
+    public void setFormat(PlantUMLDiagramFormat format)
+    {
+        this.format = format;
+    }
+
+    /**
+     * @return (optional) PlantUML diagram output format (see {@link PlantUMLDiagramFormat})
+     * @since 2.4
+     */
+    public PlantUMLDiagramFormat getFormat()
+    {
+        return format;
     }
 
     /**
@@ -104,6 +125,7 @@ public class PlantUMLMacroParameters
         PlantUMLMacroParameters rhs = (PlantUMLMacroParameters) object;
         return new EqualsBuilder()
             .append(getServer(), rhs.getServer())
+            .append(getFormat(), rhs.getFormat())
             .isEquals();
     }
 
@@ -112,6 +134,7 @@ public class PlantUMLMacroParameters
     {
         return new HashCodeBuilder(5, 37)
             .append(getServer())
+            .append(getFormat())
             .toHashCode();
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLRenderer.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/PlantUMLRenderer.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.plantuml;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.macro.MacroExecutionException;
+
+/**
+ * Render PlantUML diagram as a wiki {@link org.xwiki.rendering.block.Block}.
+ *
+ * @version $Id$
+ * @since 2.4
+ */
+@Role
+public interface PlantUMLRenderer
+{
+    /**
+     * Render specific {@link org.xwiki.rendering.block.Block} on the basis of generated diagram and output format.
+     * Depending on the {@link PlantUMLDiagramFormat} returned Block can be
+     * either {@link org.xwiki.rendering.block.ImageBlock} for image resource
+     * or {@link org.xwiki.rendering.block.RawBlock} for embedded text.
+     *
+     * @param content diagram as a code (see {@link PlantUMLGenerator#outputImage})
+     * @param serverURL optional generator URL  (see {@link PlantUMLGenerator#outputImage})
+     * @param diagramFormat diagram output format (see {@link PlantUMLDiagramFormat})
+     * @return diagram specific {@link org.xwiki.rendering.block.Block}
+     * @throws MacroExecutionException if generating or rendering of the diagram fails
+     */
+    Block renderDiagram(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException;
+}

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLConfiguration.java
@@ -56,4 +56,10 @@ public class DefaultPlantUMLConfiguration implements PlantUMLConfiguration
         }
         return serverURL;
     }
+
+    @Override
+    public String getPlantUMLOutputFormat()
+    {
+        return this.xwikiPropertiesConfigurationSource.getProperty("plantuml.format");
+    }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLConfiguration.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLConfiguration.java
@@ -26,6 +26,7 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.contrib.plantuml.PlantUMLConfiguration;
+import org.xwiki.contrib.plantuml.PlantUMLDiagramFormat;
 
 /**
  * Implementation of the PlantUML configuration.
@@ -58,8 +59,9 @@ public class DefaultPlantUMLConfiguration implements PlantUMLConfiguration
     }
 
     @Override
-    public String getPlantUMLOutputFormat()
+    public PlantUMLDiagramFormat getPlantUMLOutputFormat()
     {
-        return this.xwikiPropertiesConfigurationSource.getProperty("plantuml.format");
+        String format = this.xwikiPropertiesConfigurationSource.getProperty("plantuml.format", "png");
+        return PlantUMLDiagramFormat.fromString(format);
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLGenerator.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLGenerator.java
@@ -34,12 +34,13 @@ import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.poi.util.IOUtils;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.plantuml.PlantUMLDiagramFormat;
 import org.xwiki.contrib.plantuml.PlantUMLGenerator;
 
 import net.sourceforge.plantuml.SourceStringReader;
+import net.sourceforge.plantuml.code.TranscoderUtil;
 import net.sourceforge.plantuml.FileFormat;
 import net.sourceforge.plantuml.FileFormatOption;
-import net.sourceforge.plantuml.code.TranscoderUtil;
 
 /**
  * Generate an image from a textual definition, using PlantUML.
@@ -52,13 +53,13 @@ import net.sourceforge.plantuml.code.TranscoderUtil;
 public class DefaultPlantUMLGenerator implements PlantUMLGenerator
 {
     @Override
-    public void outputImage(String input, OutputStream outputStream, String serverURL) throws IOException
+    public void outputImage(String input, OutputStream outputStream, String serverURL, PlantUMLDiagramFormat format)
+            throws IOException
     {
-        FileFormat fileFormat = FileFormat.PNG;
         if (StringUtils.isEmpty(serverURL)) {
-            internalGenerator(input, outputStream, fileFormat);
+            internalGenerator(input, outputStream, format.getFileFormat());
         } else {
-            externalGenerator(input, outputStream, serverURL, fileFormat.name().toLowerCase());
+            externalGenerator(input, outputStream, serverURL, format.getPathParameter());
         }
     }
 

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
@@ -74,6 +74,7 @@ public class DefaultPlantUMLRenderer implements PlantUMLRenderer
         renderers = new HashMap<>();
         renderers.put(PlantUMLDiagramFormat.png, this::renderImageBlock);
         renderers.put(PlantUMLDiagramFormat.svg, this::renderRawBlock);
+        renderers.put(PlantUMLDiagramFormat.txt, this::renderPreBlock);
     }
 
     /**
@@ -95,6 +96,13 @@ public class DefaultPlantUMLRenderer implements PlantUMLRenderer
     {
         String text = renderToString(content, serverURL, diagramFormat);
         return new RawBlock(text, Syntax.XHTML_1_0);
+    }
+
+    private Block renderPreBlock(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException
+    {
+        String text = renderToString(content, serverURL, diagramFormat);
+        return new RawBlock(String.format("<pre>\n%s\n</pre>", text), Syntax.XHTML_1_0);
     }
 
     private String renderToString(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
@@ -120,8 +120,8 @@ public class DefaultPlantUMLRenderer implements PlantUMLRenderer
     private Block renderImageBlock(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
             throws MacroExecutionException
     {
-        String imageFilename = getImageFilename(content, diagramFormat.getFileFormat().getFileSuffix());
-        try (OutputStream os = this.imageWriter.getOutputStream(imageFilename)) {
+        String imageId = getImageId(content, diagramFormat.getFileFormat().getFileSuffix());
+        try (OutputStream os = this.imageWriter.getOutputStream(imageId)) {
             this.plantUMLGenerator.outputImage(content, os, serverURL, diagramFormat);
         } catch (IOException e) {
             throw new MacroExecutionException(
@@ -130,11 +130,11 @@ public class DefaultPlantUMLRenderer implements PlantUMLRenderer
 
         // Return the image block pointing to the generated image.
         ResourceReference resourceReference =
-                new ResourceReference(this.imageWriter.getURL(imageFilename).serialize(), ResourceType.URL);
+                new ResourceReference(this.imageWriter.getURL(imageId).serialize(), ResourceType.URL);
         return new ImageBlock(resourceReference, false);
     }
 
-    private String getImageFilename(String content, String extension)
+    private String getImageId(String content, String extension)
     {
         return String.format("%d%s", content.hashCode(), extension);
     }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.contrib.plantuml.internal;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.contrib.plantuml.PlantUMLDiagramFormat;
+import org.xwiki.contrib.plantuml.PlantUMLGenerator;
+import org.xwiki.contrib.plantuml.PlantUMLRenderer;
+import org.xwiki.contrib.plantuml.internal.store.ImageWriter;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.ImageBlock;
+import org.xwiki.rendering.block.RawBlock;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.rendering.listener.reference.ResourceType;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.syntax.Syntax;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Render PlantUML diagram as a wiki {@link org.xwiki.rendering.block.Block}.
+ *
+ * @version $Id$
+ * @since 2.4
+ */
+@Component
+@Singleton
+public class DefaultPlantUMLRenderer implements PlantUMLRenderer
+{
+
+    @Inject
+    private PlantUMLGenerator plantUMLGenerator;
+
+    @Inject
+    @Named("tmp")
+    private ImageWriter imageWriter;
+
+    /**
+     * Local functional interface to serve rendering registry.
+     */
+    interface BlockRenderer
+    {
+        Block render(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+                throws MacroExecutionException;
+    }
+    // Map {@link org.xwiki.contrib.plantuml.PlantUMLDiagramFormat} to corresponding rendering method in registry.
+    private final Map<PlantUMLDiagramFormat, BlockRenderer> renderers;
+    {
+        renderers = new HashMap<>();
+        renderers.put(PlantUMLDiagramFormat.png, this::renderImageBlock);
+        renderers.put(PlantUMLDiagramFormat.svg, this::renderRawBlock);
+    }
+
+    /**
+     * See {@link org.xwiki.contrib.plantuml.PlantUMLRenderer#renderDiagram(String, String, PlantUMLDiagramFormat)}.
+     */
+    @Override
+    public Block renderDiagram(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException
+    {
+        BlockRenderer renderer = renderers.get(diagramFormat);
+        if (renderer == null) {
+            throw new MacroExecutionException("Unknown diagram format: " + diagramFormat);
+        }
+        return renderer.render(content, serverURL, diagramFormat);
+    }
+
+    private Block renderRawBlock(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException
+    {
+        String text = renderToString(content, serverURL, diagramFormat);
+        return new RawBlock(text, Syntax.XHTML_1_0);
+    }
+
+    private String renderToString(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException
+    {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            this.plantUMLGenerator.outputImage(content, baos, serverURL, diagramFormat);
+            return baos.toString(StandardCharsets.UTF_8.name());
+        } catch (IOException e) {
+            throw new MacroExecutionException(
+                    String.format("Failed to generate a text using PlantUML for content [%s]", content), e);
+        }
+    }
+
+    private Block renderImageBlock(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)
+            throws MacroExecutionException
+    {
+        String imageFilename = getImageFilename(content, diagramFormat.getFileFormat().getFileSuffix());
+        try (OutputStream os = this.imageWriter.getOutputStream(imageFilename)) {
+            this.plantUMLGenerator.outputImage(content, os, serverURL, diagramFormat);
+        } catch (IOException e) {
+            throw new MacroExecutionException(
+                    String.format("Failed to generate an image using PlantUML for content [%s]", content), e);
+        }
+
+        // Return the image block pointing to the generated image.
+        ResourceReference resourceReference =
+                new ResourceReference(this.imageWriter.getURL(imageFilename).serialize(), ResourceType.URL);
+        return new ImageBlock(resourceReference, false);
+    }
+
+    private String getImageFilename(String content, String extension)
+    {
+        return String.format("%d%s", content.hashCode(), extension);
+    }
+}

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/DefaultPlantUMLRenderer.java
@@ -102,7 +102,18 @@ public class DefaultPlantUMLRenderer implements PlantUMLRenderer
             throws MacroExecutionException
     {
         String text = renderToString(content, serverURL, diagramFormat);
-        return new RawBlock(String.format("<pre>\n%s\n</pre>", text), Syntax.XHTML_1_0);
+        return new RawBlock(String.format("<pre>\n%s\n</pre>", escapeHtml(text)), Syntax.XHTML_1_0);
+    }
+
+    private String escapeHtml(String text)
+    {
+        if (text == null) {
+            return null;
+        }
+        return text
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;");
     }
 
     private String renderToString(String content, String serverURL, PlantUMLDiagramFormat diagramFormat)

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/PlantUMLMacro.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/PlantUMLMacro.java
@@ -166,7 +166,11 @@ public class PlantUMLMacro extends AbstractMacro<PlantUMLMacroParameters>
     {
         PlantUMLDiagramFormat format = parameters.getFormat();
         if (format == null) {
-            format = PlantUMLDiagramFormat.fromString(this.configuration.getPlantUMLOutputFormat());
+            format = this.configuration.getPlantUMLOutputFormat();
+            if (format == null) {
+                // fallback if mocked configuration implementation returns null
+                format = PlantUMLDiagramFormat.png;
+            }
         }
         return format;
     }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/ImageWriter.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/ImageWriter.java
@@ -36,19 +36,19 @@ import org.xwiki.url.ExtendedURL;
 public interface ImageWriter
 {
     /**
-     * @param imageFilename the image id that we use to generate a unique storage location
+     * @param imageId the image id that we use to generate a unique storage location
      * @return the output stream into which to write to save the image data to disk
      * @throws MacroExecutionException if the target file cannot be created (already exists and is a directory, etc)
      */
-    OutputStream getOutputStream(String imageFilename) throws MacroExecutionException;
+    OutputStream getOutputStream(String imageId) throws MacroExecutionException;
 
     /**
      * Compute the URL to use to access the stored generate chart image.
      *
-     * @param imageFilename the image id for the image that we have stored
+     * @param imageId the image id for the image that we have stored
      * @return the URL to use to access the stored generate chart image
      * @throws MacroExecutionException if an error happened when computing the URL (eg if the current wiki cannot be
      *         computed)
      */
-    ExtendedURL getURL(String imageFilename) throws MacroExecutionException;
+    ExtendedURL getURL(String imageId) throws MacroExecutionException;
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/ImageWriter.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/ImageWriter.java
@@ -36,19 +36,19 @@ import org.xwiki.url.ExtendedURL;
 public interface ImageWriter
 {
     /**
-     * @param imageId the image id that we use to generate a unique storage location
+     * @param imageFilename the image id that we use to generate a unique storage location
      * @return the output stream into which to write to save the image data to disk
      * @throws MacroExecutionException if the target file cannot be created (already exists and is a directory, etc)
      */
-    OutputStream getOutputStream(String imageId) throws MacroExecutionException;
+    OutputStream getOutputStream(String imageFilename) throws MacroExecutionException;
 
     /**
      * Compute the URL to use to access the stored generate chart image.
      *
-     * @param imageId the image id for the image that we have stored
+     * @param imageFilename the image id for the image that we have stored
      * @return the URL to use to access the stored generate chart image
      * @throws MacroExecutionException if an error happened when computing the URL (eg if the current wiki cannot be
      *         computed)
      */
-    ExtendedURL getURL(String imageId) throws MacroExecutionException;
+    ExtendedURL getURL(String imageFilename) throws MacroExecutionException;
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
@@ -74,17 +74,17 @@ public class TemporaryImageWriter implements ImageWriter
     private ResourceReferenceSerializer<TemporaryResourceReference, ExtendedURL> temporaryResourceSerializer;
 
     @Override
-    public OutputStream getOutputStream(String imageFilename) throws MacroExecutionException
+    public OutputStream getOutputStream(String imageId) throws MacroExecutionException
     {
         OutputStream result;
-        File imageFile = getStorageLocation(imageFilename);
+        File imageFile = getStorageLocation(imageId);
         // Make sure that the directory exist
         imageFile.getParentFile().mkdirs();
         try {
             result = new FileOutputStream(imageFile);
         } catch (IOException e) {
             throw new MacroExecutionException(
-                String.format("Failed to create the PlantUML image file for image id [%s]", imageFilename), e);
+                String.format("Failed to create the PlantUML image file for image id [%s]", imageId), e);
         }
         return result;
     }
@@ -92,13 +92,13 @@ public class TemporaryImageWriter implements ImageWriter
     /**
      * Compute the location where to store the generated image.
      *
-     * @param imageFilename the image id that we use to generate a storage location
+     * @param imageId the image id that we use to generate a storage location
      * @return the location where to store the generated image
      * @throws MacroExecutionException if an error happened when computing the location
      */
-    protected File getStorageLocation(String imageFilename) throws MacroExecutionException
+    protected File getStorageLocation(String imageId) throws MacroExecutionException
     {
-        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageFilename);
+        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageId);
         try {
             return this.temporaryResourceStore.getTemporaryFile(resourceReference);
         } catch (IOException e) {
@@ -108,9 +108,9 @@ public class TemporaryImageWriter implements ImageWriter
     }
 
     @Override
-    public ExtendedURL getURL(String imageFilename) throws MacroExecutionException
+    public ExtendedURL getURL(String imageId) throws MacroExecutionException
     {
-        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageFilename);
+        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageId);
         try {
             return this.temporaryResourceSerializer.serialize(resourceReference);
         } catch (SerializeResourceReferenceException | UnsupportedResourceReferenceException e) {
@@ -119,9 +119,9 @@ public class TemporaryImageWriter implements ImageWriter
         }
     }
 
-    private TemporaryResourceReference getTemporaryResourceReference(String imageFilename)
+    private TemporaryResourceReference getTemporaryResourceReference(String imageId)
     {
-        return new TemporaryResourceReference(MODULE_ID, imageFilename,
+        return new TemporaryResourceReference(MODULE_ID, imageId,
             this.documentAccessBridge.getCurrentDocumentReference());
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
@@ -74,17 +74,17 @@ public class TemporaryImageWriter implements ImageWriter
     private ResourceReferenceSerializer<TemporaryResourceReference, ExtendedURL> temporaryResourceSerializer;
 
     @Override
-    public OutputStream getOutputStream(String imageId) throws MacroExecutionException
+    public OutputStream getOutputStream(String imageFilename) throws MacroExecutionException
     {
         OutputStream result;
-        File imageFile = getStorageLocation(imageId);
+        File imageFile = getStorageLocation(imageFilename);
         // Make sure that the directory exist
         imageFile.getParentFile().mkdirs();
         try {
             result = new FileOutputStream(imageFile);
         } catch (IOException e) {
             throw new MacroExecutionException(
-                String.format("Failed to create the PlantUML image file for image id [%s]", imageId), e);
+                    String.format("Failed to create the PlantUML image file for image id [%s]", imageFilename), e);
         }
         return result;
     }
@@ -92,13 +92,13 @@ public class TemporaryImageWriter implements ImageWriter
     /**
      * Compute the location where to store the generated image.
      *
-     * @param imageId the image id that we use to generate a storage location
+     * @param imageFilename the image id that we use to generate a storage location
      * @return the location where to store the generated image
      * @throws MacroExecutionException if an error happened when computing the location
      */
-    protected File getStorageLocation(String imageId) throws MacroExecutionException
+    protected File getStorageLocation(String imageFilename) throws MacroExecutionException
     {
-        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageId);
+        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageFilename);
         try {
             return this.temporaryResourceStore.getTemporaryFile(resourceReference);
         } catch (IOException e) {
@@ -108,9 +108,9 @@ public class TemporaryImageWriter implements ImageWriter
     }
 
     @Override
-    public ExtendedURL getURL(String imageId) throws MacroExecutionException
+    public ExtendedURL getURL(String imageFilename) throws MacroExecutionException
     {
-        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageId);
+        TemporaryResourceReference resourceReference = getTemporaryResourceReference(imageFilename);
         try {
             return this.temporaryResourceSerializer.serialize(resourceReference);
         } catch (SerializeResourceReferenceException | UnsupportedResourceReferenceException e) {
@@ -119,9 +119,9 @@ public class TemporaryImageWriter implements ImageWriter
         }
     }
 
-    private TemporaryResourceReference getTemporaryResourceReference(String imageId)
+    private TemporaryResourceReference getTemporaryResourceReference(String imageFilename)
     {
-        return new TemporaryResourceReference(MODULE_ID, String.format("%s.png", imageId),
+        return new TemporaryResourceReference(MODULE_ID, imageFilename,
             this.documentAccessBridge.getCurrentDocumentReference());
     }
 }

--- a/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
+++ b/macro-plantuml-macro/src/main/java/org/xwiki/contrib/plantuml/internal/store/TemporaryImageWriter.java
@@ -84,7 +84,7 @@ public class TemporaryImageWriter implements ImageWriter
             result = new FileOutputStream(imageFile);
         } catch (IOException e) {
             throw new MacroExecutionException(
-                    String.format("Failed to create the PlantUML image file for image id [%s]", imageFilename), e);
+                String.format("Failed to create the PlantUML image file for image id [%s]", imageFilename), e);
         }
         return result;
     }

--- a/macro-plantuml-macro/src/main/resources/META-INF/components.txt
+++ b/macro-plantuml-macro/src/main/resources/META-INF/components.txt
@@ -4,3 +4,4 @@ org.xwiki.contrib.plantuml.internal.PlantUMLBlockAsyncRenderer
 org.xwiki.contrib.plantuml.internal.DefaultPlantUMLConfiguration
 org.xwiki.contrib.plantuml.internal.PlantUMLConfigClassDocumentConfigurationSource
 org.xwiki.contrib.plantuml.internal.store.TemporaryImageWriter
+org.xwiki.contrib.plantuml.internal.DefaultPlantUMLRenderer


### PR DESCRIPTION
[PLANTUML-15](https://jira.xwiki.org/browse/PLANTUML-15): Allow setting output format for generated diagram

Add `format` macro parameter and `plantuml.format` system-wide configuration for diagram output format.
Supported values are: `svg`, `png`, `txt`.
Motivation:
- `svg` scales better than `png`;
- embedded `svg` supports hyperlinks and may be used for navigation;
- generating of `svg` requires no extra files.