### PR TITLE
PLANTUML-15: Allow setting output format for generated diagram

### DIFF
--- a/macro-plantuml-macro/src/test/resources/macroplantuml4.test
+++ b/macro-plantuml-macro/src/test/resources/macroplantuml4.test
@@ -1,0 +1,14 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Test the PlantUML macro with svg format parameter
+.#-----------------------------------------------------
+{{plantuml format="svg"}}
+@startuml
+Bob -> Alice : hello
+@enduml
+{{/plantuml}}
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<div><svg ${{{regex:.+?}}} data-diagram-type="SEQUENCE"${{{regex:.+?}}}<title>Bob</title>${{{regex:.+?}}}<title>Alice</title>${{{regex:.+?}}}</svg></div>

--- a/macro-plantuml-macro/src/test/resources/macroplantuml5.test
+++ b/macro-plantuml-macro/src/test/resources/macroplantuml5.test
@@ -1,0 +1,14 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Test the PlantUML macro with txt format parameter
+.#-----------------------------------------------------
+{{plantuml format="txt"}}
+@startuml
+Bob -> Alice : hello
+@enduml
+{{/plantuml}}
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<div><pre>${{{regex:.+?}}}|Bob|${{{regex:.+?}}}|Alice|${{{regex:.+?}}}hello${{{regex:.+?}}}-&gt;|${{{regex:.+?}}}</pre></div>


### PR DESCRIPTION
* Add `macroplantuml4.test` to verify the diagram output in `svg` format.
* Add `macroplantuml5.test` to verify the diagram output in `txt` format.